### PR TITLE
temporary: disable signup/login until SMTP situation figured out

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -4,7 +4,8 @@ export default function Page() {
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
-        <LoginForm />
+        {/* <LoginForm /> */}
+        404 - Page Not Found
       </div>
     </div>
   );

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -4,7 +4,8 @@ export default function Page() {
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
-        <SignUpForm />
+        {/* <SignUpForm /> */}
+        404 - Page Not Found
       </div>
     </div>
   );

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -47,17 +47,18 @@ export async function updateSession(request: NextRequest) {
   const { data } = await supabase.auth.getClaims();
   const user = data?.claims;
 
-  if (
-    request.nextUrl.pathname !== "/" &&
-    !user &&
-    !request.nextUrl.pathname.startsWith("/login") &&
-    !request.nextUrl.pathname.startsWith("/auth")
-  ) {
-    // no user, potentially respond by redirecting the user to the login page
-    const url = request.nextUrl.clone();
-    url.pathname = "/auth/login";
-    return NextResponse.redirect(url);
-  }
+  // TODO: Uncomment this section to enable redirecting users to login page
+  // if (
+  //   request.nextUrl.pathname !== "/" &&
+  //   !user &&
+  //   !request.nextUrl.pathname.startsWith("/login") &&
+  //   !request.nextUrl.pathname.startsWith("/auth")
+  // ) {
+  //   // no user, potentially respond by redirecting the user to the login page
+  //   const url = request.nextUrl.clone();
+  //   url.pathname = "/auth/login";
+  //   return NextResponse.redirect(url);
+  // }
 
   // IMPORTANT: You *must* return the supabaseResponse object as it is.
   // If you're creating a new response object with NextResponse.next() make sure to:


### PR DESCRIPTION
CLOSES #12 

Changes made:
- Without deleting `auth/login` and `auth/sign-up` endpoints (would be a hassle to retrieve them), I hid the forms and just put "404 - Page Not Found" for now
- Disable auth redirect to `auth/login` since pages developed for the time being will be open to the public